### PR TITLE
[mellow/rstETH] update links and name

### DIFF
--- a/vaults/0x7b276aAD6D2ebfD7e270C5a2697ac79182D9550E/info.json
+++ b/vaults/0x7b276aAD6D2ebfD7e270C5a2697ac79182D9550E/info.json
@@ -2,17 +2,27 @@
     "description": "Restaking Vault curated by re7 Labs aims to maximize restaking opportunities for its users. P2P.org is a global staking & restaking leader with $8B and over 100k delegators across 50+ networks. Depositing this Vault you accept [disclaimer](https://cdn.p2p.org/legal/restaking-vault.pdf)",
     "links": [
         {
-            "name": "Mellow.finance",
+            "name": "Website",
             "type": "website",
+            "url": "https://mellow.finance/"
+        },
+        {
+            "name": "Deposit",
+            "type": "externalLink",
             "url": "https://app.mellow.finance/partners/p2p/vaults/ethereum-rsteth"
         },
         {
-            "name": "Vault Documentation",
+            "type": "explorer",
+            "name": "Etherscan",
+            "url": "https://etherscan.io/address/0x7b276aAD6D2ebfD7e270C5a2697ac79182D9550E"
+        },
+        {
+            "name": "Documentation",
             "type": "docs",
-            "url": "https://docs.mellow.finance/mellow-lrt-lst-primitive/lrt-contracts"
+            "url": "https://docs.mellow.finance/mellow-lrt-lst-primitive/simple-lrt"
         }
     ],
-    "name": "Restaking Vault ETH",
+    "name": "Restaking Vault ETH [all Networks]",
     "tags": [
         "mellow",
         "P2P.org",


### PR DESCRIPTION
Updated vault entity: 0x7b276aAD6D2ebfD7e270C5a2697ac79182D9550E

Name: Restaking Vault ETH [all Networks]
Description: Restaking Vault curated by re7 Labs aims to maximize restaking opportunities for its users.
Tags: mellow, P2P.org, re7 Labs

Links:
[Website](https://app.mellow.finance/partners/p2p/vaults/ethereum-rsteth)
[Docs](https://docs.mellow.finance/mellow-lrt-lst-primitive/simple-lrt)
[explorer](https://etherscan.io/address/0x7b276aAD6D2ebfD7e270C5a2697ac79182D9550E)
[externalLink](https://app.mellow.finance/partners/p2p/vaults/ethereum-rsteth)

Icon: Included (256x256 px)