### PR TITLE
Add 0G token metadata (W0G and 0G Vault OFT)

### DIFF
--- a/tokens/0x4C1Dab3Be86347977F3DfC4b9688224ef2272939/info.json
+++ b/tokens/0x4C1Dab3Be86347977F3DfC4b9688224ef2272939/info.json
@@ -1,0 +1,28 @@
+{
+    "name": "Wrapped 0G",
+    "description": "Wrapped 0G (W0G) is the ERC-20 wrapper of the native 0G token, used as collateral for validator restaking on the 0G network. 0G is the Blockchain for AI Agents, a modular Layer 1 integrating chain, storage, data availability, and compute to power verifiable, fully onchain AI at scale.",
+    "tags": ["0G", "Wrapped", "W0G"],
+    "links": [
+        {
+            "type": "website",
+            "name": "Website",
+            "url": "https://0g.ai"
+        },
+        {
+            "type": "docs",
+            "name": "Documentation",
+            "url": "https://docs.0g.ai"
+        },
+        {
+            "type": "explorer",
+            "name": "Etherscan",
+            "url": "https://etherscan.io/address/0x4C1Dab3Be86347977F3DfC4b9688224ef2272939"
+        },
+        {
+            "type": "externalLink",
+            "name": "0G Chainscan",
+            "url": "https://chainscan.0g.ai"
+        }
+    ],
+    "cmcId": "38337"
+}

--- a/tokens/0xE42215BD71E190b3864267569c2f66077260EaE4/info.json
+++ b/tokens/0xE42215BD71E190b3864267569c2f66077260EaE4/info.json
@@ -1,0 +1,27 @@
+{
+    "name": "0G Vault OFT",
+    "description": "0G Vault OFT (0G OFT) is the LayerZero OFT representation on Ethereum of the Mellow Interop SourceCore (Ascend Staked OG) vault on 0G chain. Users deposit Wrapped 0G into the 0G-chain vault, and the bridged OFT on Ethereum is used as restaking collateral on the 0G network via Symbiotic.",
+    "tags": ["token", "0G Vault OFT", "Mellow", "0G"],
+    "links": [
+        {
+            "type": "website",
+            "name": "Mellow Website",
+            "url": "https://mellow.finance/"
+        },
+        {
+            "type": "docs",
+            "name": "Mellow Documentation",
+            "url": "https://docs.mellow.finance/mellow-lrt-lst-primitive/interoperable-vaults"
+        },
+        {
+            "type": "explorer",
+            "name": "Etherscan",
+            "url": "https://etherscan.io/address/0xE42215BD71E190b3864267569c2f66077260EaE4"
+        },
+        {
+            "type": "externalLink",
+            "name": "0G Network",
+            "url": "https://0g.ai"
+        }
+    ]
+}


### PR DESCRIPTION
**Entity Type**: token

Adds metadata for the two ERC-20 collateral tokens whitelisted in the 0G restaking network (`ZeroGravityFactory` at `0xd5AB0eD30D65f01EC6d6A4BaCA6E466F395334b6`):

- `0x4C1Dab3Be86347977F3DfC4b9688224ef2272939` — **Wrapped 0G (W0G)** — ERC-20 wrapper of the native 0G token
- `0xE42215BD71E190b3864267569c2f66077260EaE4` — **0G Vault OFT (0G OFT)** — LayerZero OFT representation on Ethereum of the Mellow Interop SourceCore (Ascend Staked OG) vault deployed on 0G chain

Both tokens are actively configured as collateral in the 0G network registered in #477. A third, deprecated OFT (`0x2b38d351...`) has `minValidatorDeposit = 0` and is intentionally omitted.

I will email this PR link to verify@symbiotic.fi from fan.wang@0g.ai to confirm identity.