### PR TITLE
fix: description for Re7 Labs

### DIFF
--- a/curators/re7-labs/info.json
+++ b/curators/re7-labs/info.json
@@ -1,6 +1,6 @@
 {
     "name": "Re7 Labs",
-    "description": "Concrete is DeFi Yield Infrastructure - powering secure yields and new derivatives for on-chain assets.",
+    "description": "Re7 Labs is the innovation arm of digital asset investment firm Re7 Capital, applying practical DeFi risk management expertise to onchain vault strategies.",
     "links": [
         {
             "type": "website",


### PR DESCRIPTION
- Replaced the incorrect project description, which referenced Concrete, with an accurate description of Re7 Labs based on its official positioning.