### PR TITLE
Enable unsafe PR checkout for validation workflow

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -23,12 +23,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # pin@v7.0.0
         with:
+          allow-unsafe-pr-checkout: true
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Checkout upstream
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # pin@v7.0.0
         with:
+          allow-unsafe-pr-checkout: true
           path: upstream
           ref: main
           repository: ${{ github.event.pull_request.base.repo.full_name }}


### PR DESCRIPTION
Added 'allow-unsafe-pr-checkout' option to checkout actions.