### PR TITLE
Add missing vault curator associations

### DIFF
--- a/vaults/0x087cbB1a89aA038A167E27588B5eC01484b40Fb7/info.json
+++ b/vaults/0x087cbB1a89aA038A167E27588B5eC01484b40Fb7/info.json
@@ -23,5 +23,6 @@
     "Cap",
     "Flow Traders"
   ],
+  "curatorId": "lombard",
   "vaultType": "network-exclusive"
 }

--- a/vaults/0x2Bcfa0283C92b7845ECE12cEaDc521414BeF1067/info.json
+++ b/vaults/0x2Bcfa0283C92b7845ECE12cEaDc521414BeF1067/info.json
@@ -5,6 +5,7 @@
         "vault",
         "token:ETHFI"
     ],
+    "curatorId": "etherfi",
     "links": [
         {
             "type": "externalLink",

--- a/vaults/0x5b1c752840cba714e97afcd75cd0edee5821b133/info.json
+++ b/vaults/0x5b1c752840cba714e97afcd75cd0edee5821b133/info.json
@@ -23,5 +23,6 @@
     "Cap",
     "Re7 Capital"
   ],
+  "curatorId": "re7-labs",
   "vaultType": "network-exclusive"
 }

--- a/vaults/0x8327b8BD2561d28F914931aD57370d62C7968e40/info.json
+++ b/vaults/0x8327b8BD2561d28F914931aD57370d62C7968e40/info.json
@@ -34,5 +34,6 @@
       "url": "https://etherscan.io/address/0x8327b8bd2561d28f914931ad57370d62c7968e40"
     }
   ],
+  "curatorId": "gauntlet",
   "vaultType": "eth-restaking"
 }

--- a/vaults/0x945d97354fae3c609f27a1d6c6608a98d42563ed/info.json
+++ b/vaults/0x945d97354fae3c609f27a1d6c6608a98d42563ed/info.json
@@ -22,5 +22,6 @@
       "url": "https://www.gauntlet.xyz/resources/a-deep-dive-into-our-symbiotic-restaking-vault-strategy"
     }
   ],
+  "curatorId": "gauntlet",
   "vaultType": "eth-restaking"
 }

--- a/vaults/0x9fafca9108762ab320aedb7d0c76102b17285ced/info.json
+++ b/vaults/0x9fafca9108762ab320aedb7d0c76102b17285ced/info.json
@@ -23,5 +23,6 @@
     "Cap",
     "Portofino"
   ],
+  "curatorId": "bedrock",
   "vaultType": "network-exclusive"
 }

--- a/vaults/0xEa0F2EA61998346aD39dddeF7513ae90915AFb3c/info.json
+++ b/vaults/0xEa0F2EA61998346aD39dddeF7513ae90915AFb3c/info.json
@@ -36,5 +36,6 @@
 			"type": "defaultStakingRewardsV2Epoched"
 		}
 	],
+	"curatorId": "mev-capital",
 	"vaultType": "eth-restaking"
 }

--- a/vaults/0xa5C47FE5C30d2547ddc1ccEfac5a515902178dE6/info.json
+++ b/vaults/0xa5C47FE5C30d2547ddc1ccEfac5a515902178dE6/info.json
@@ -32,5 +32,6 @@
     "mellow",
     "MEV"
   ],
+  "curatorId": "mev-capital",
   "vaultType": "btc-restaking"
 }

--- a/vaults/0xabe79b5004f0738c38017633d81654eaef3b416d/info.json
+++ b/vaults/0xabe79b5004f0738c38017633d81654eaef3b416d/info.json
@@ -23,5 +23,6 @@
     "Cap",
     "Flowdesk"
   ],
+  "curatorId": "bedrock",
   "vaultType": "network-exclusive"
 }

--- a/vaults/0xca5412f167228f33571a1d2c1fccf28f5b74ab59/info.json
+++ b/vaults/0xca5412f167228f33571a1d2c1fccf28f5b74ab59/info.json
@@ -23,5 +23,6 @@
     "Cap",
     "Selini Capital"
   ],
+  "curatorId": "bedrock",
   "vaultType": "network-exclusive"
 }


### PR DESCRIPTION
## Summary

- attach ten approved vault metadata records to their existing curator entities
- add mappings for Gauntlet (2), Etherfi (1), Lombard (1), Re7 Labs (1), Bedrock (3), and MEV Capital (2)
- keep the change limited to `curatorId` fields

## Why

The Curator UI builds curator filter options and matching behavior from vault `curatorId` metadata. These ten records had strong curator evidence but no association, so they were omitted whenever users filtered by the related curator.

The omissions came from incomplete curator-name migration and later copied or synchronized vault metadata that did not preserve the existing association.

## Impact

The affected vaults will appear under their related curators in clients consuming `metadata-mainnet`. The number of vault metadata records with valid curator associations increases from 74 to 84.

## Validation

- parsed every repository `info.json` with `jq`
- verified all `curatorId` values resolve to existing `curators/<id>` directories
- asserted the ten requested address-to-curator mappings
- verified the total linked-vault count is 84
- ran `git diff --check`
