### PR TITLE
Update support link on Ether.fi by P2P.org operator entry

### DIFF
--- a/operators/0xFC32d67BfabB37Fa50eb63c11d81790681D82c14/info.json
+++ b/operators/0xFC32d67BfabB37Fa50eb63c11d81790681D82c14/info.json
@@ -17,8 +17,8 @@
 		},
                 {
                         "type": "website",
-                        "name": "Telegram",
-                        "url": "https://t.me/P2P_staking_support_bot"
+                        "name": "Support",
+                        "url": "https://support.p2p.org"
                 },
                 {
                         "type": "website",


### PR DESCRIPTION
## Summary

Updates the support link on the existing **operator** entry `0xFC32d67BfabB37Fa50eb63c11d81790681D82c14` (Ether.fi by P2P.org), owned by P2P.org.

The entry currently lists a Telegram username that P2P.org no longer controls: the original support account was deleted, and the username has since been re-registered by an unrelated third party impersonating us. We would appreciate a prompt review, since the stale link currently sends users to that account.

The link is repointed to our official support entry point, `https://support.p2p.org` (a stable redirect we control, so it will not go stale again):

```diff
                         "type": "website",
-                        "name": "Telegram",
-                        "url": "https://t.me/P2P_staking_support_bot"
+                        "name": "Support",
+                        "url": "https://support.p2p.org"
```

Only this one entity is changed, per the one-entity-per-PR rule. `info.json` remains valid JSON, no logo or other fields are touched, and the operator is already registered in the operator registry. The same stale link appears on two further P2P.org operator entries, submitted separately as #505 and #506.

Per the contribution guide, the PR link is being emailed to verify@symbiotic.fi from a @p2p.org address for identity verification.