### PR TITLE
Fix: Pin metadata validator action to audited commit

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Validate
         if: steps.changes.outputs.exists == 'true'
-        uses: symbioticfi/metadata-validation-scripts@main
+        uses: symbioticfi/metadata-validation-scripts@a21a6f01a2b6c5fda769e0c7c0b55d79172568f6 # pin@main (audited commit)
         with:
           files: ${{ steps.changes.outputs.files }}
           issue: ${{ github.event.number }}


### PR DESCRIPTION
### Description
This PR addresses a supply-chain security risk identified during the workspace-wide audit by eliminating a mutable GitHub Action reference in the CI pipeline[cite: 34].

### Key Changes
* **Mutable Action Reference (`.github/workflows/validate-pr.yml`):** The metadata validator action was previously pointing to the mutable `main` branch[cite: 34]. To ensure execution consistency and prevent upstream supply-chain attacks, the action reference is now strictly pinned to the audited commit SHA (`a21a6f01a2b6c5fda769e0c7c0b55d79172568f6`)[cite: 34].